### PR TITLE
fix: postcss套件組態

### DIFF
--- a/client/eslint.config.mts
+++ b/client/eslint.config.mts
@@ -42,7 +42,7 @@ export default [
     // "plugin:prettier/recommended",
     // "prettier",
     // "plugin:vuejs-accessibility/recommended",
-    // process.env.NPM_ENV === "development"
+    // process.env.NODE_ENV === "development"
     //         ? "./.eslintrc-auto-import.json"
     //         : "",
     // ),

--- a/client/postcss.config.mts
+++ b/client/postcss.config.mts
@@ -6,7 +6,7 @@ export default {
         //But others, like autoprefixer, need to run after,
         autoprefixer: {},
         cssnano:
-            process.env.NPM_ENV === 'production'
+            process.env.NODE_ENV === 'production'
                 ? { preset: 'advanced' }
                 : false
     }


### PR DESCRIPTION
 - NODE_ENV是Web開發中常用的環境變量， 用於指定Web應用程式目前運行的環境。 根據上下文，它可以採用不同的值， 例如“development”、“production”。
 - 在提供的程式碼片段中， 正在檢查 `process.env.NODE_ENV` 的值以確定是否應套用某些配置。 例如：
 1. 在 `eslint.config.mts` 檔案中， 僅當環境設定為「development」時， 用於有條件地包含 ESLint 設定檔 (`./.eslintrc-auto-import.json`)， 不過先前已透過@eslint/migrate-config指令遷移至新式Eslint Flat Config， 現已棄用，註解作爲參考。
 2. 在`postcss.config.mts`檔案中， 它用於根據環境是否為「production」來決定是否應該使用進階的預先配置來設定`cssnano`外掛程式還是完全停用保持可讀性。
 - 這種方法允許開發人員根據不同的環境自訂建置和開發流程， 確保在正式環境中應用最佳化， 同時在開發過程中維護更詳細的配置， 以便於偵錯和測試。